### PR TITLE
load weapon component in manifest

### DIFF
--- a/cWeaponsToolkit.cpp
+++ b/cWeaponsToolkit.cpp
@@ -690,6 +690,8 @@ void cWeaponsToolkit::onExportButtonPressed(wxCommandEvent& evt)
 
 		manifest << "files{\n";
 		manifest << "	'**/weaponcomponents.meta',\n";
+		manifest << "	'**/**/weaponcomponents.meta',\n";
+		manifest << "	'**/**/**/weaponcomponents.meta',\n";
 		manifest << "	'**/weaponarchetypes.meta',\n";
 		manifest << "	'**/weaponanimations.meta',\n";
 		manifest << "	'**/pedpersonality.meta',\n";
@@ -697,6 +699,8 @@ void cWeaponsToolkit::onExportButtonPressed(wxCommandEvent& evt)
 		manifest << "}\n";
 		manifest << "\n";
 		manifest << "data_file 'WEAPONCOMPONENTSINFO_FILE' '**/weaponcomponents.meta'\n";
+		manifest << "data_file 'WEAPONCOMPONENTSINFO_FILE' '**/**/weaponcomponents.meta'\n";
+		manifest << "data_file 'WEAPONCOMPONENTSINFO_FILE' '**/**/**/weaponcomponents.meta'\n";
 		manifest << "data_file 'WEAPON_METADATA_FILE' '**/weaponarchetypes.meta'\n";
 		manifest << "data_file 'WEAPON_ANIMATIONS_FILE' '**/weaponanimations.meta'\n";
 		manifest << "data_file 'PED_PERSONALITY_FILE' '**/pedpersonality.meta'\n";


### PR DESCRIPTION
I know its crazy that how work for me :|
that is not just this it happen for all I know fivem said this
![image](https://user-images.githubusercontent.com/20565441/131289429-83c7ccbd-9969-4a9f-b2ff-d9def82b3e0e.png)

but when it just
`**/weaponcomponents.meta`
![image](https://user-images.githubusercontent.com/20565441/131289326-49a762d3-7756-4f56-9a3a-09e589c3378d.png)

but correct one
![image](https://user-images.githubusercontent.com/20565441/131289373-fe29bd4c-8cd2-4899-876f-590808b2fb49.png)
